### PR TITLE
remove donate, add settings placeholder

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "version": "0.9",
   "browser_action": {
    "default_icon": "favicon-32x32.png",
-   "default_popup": "donate.html"
+   "default_popup": "settings.html"
   },
    "icons": {
       "128": "favicon-128x128.png",

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,2 @@
+<!--settings panel placeholder-->
+


### PR DESCRIPTION
Hi, the donate will live on an external website. I went ahead and swapped out the legacy and updated manifest.